### PR TITLE
fix(local-repo-hook): Tolerate unknown hook type

### DIFF
--- a/scripts/local-scripts.sh
+++ b/scripts/local-scripts.sh
@@ -5,7 +5,7 @@ DEFAULT_HOOK_DIR=.git/hooks
 hook_type=$(ps -p $PPID -wwf | grep -Eo -- "--hook-type=.*? " | cut -d= -f2 | xargs)
 if [[ "${hook_type}x" = "x" ]] ; then
   echo "Unable to determine hook type"
-  exit 1
+  exit 0
 fi
 
 legacy_hook="${DEFAULT_HOOK_DIR}/${hook_type}"


### PR DESCRIPTION
If we can't determine what hook type it is, just note that and exit 0.
This happens when you're manually running hooks and so forth, and
shouldn't be an error condition.
